### PR TITLE
Do not twice decode URL escape sequences in grammar from URL

### DIFF
--- a/components/editor.vue
+++ b/components/editor.vue
@@ -128,12 +128,12 @@ export default class Editor extends Vue {
   loadGetBNF() {
     let ustr = window.location.href;
     let url = new URL(ustr);
-    let bnf = url.searchParams.get("bnf");
+    let bnf = url.searchParams.get("bnf"); // Already URI decoded
     let tit = url.searchParams.get("name");
     if (bnf) {
-      console.log("bnf is here! it should be: ", decodeURIComponent(bnf));
-      // setEnteredCode(decodeURIComponent(bnf));
-      this.editor.getDoc().setValue(decodeURIComponent(bnf));
+      console.log("bnf is here! it should be: ", bnf);
+      // setEnteredCode(bnf);
+      this.editor.getDoc().setValue(bnf);
       this.title = tit ? tit : "";
     }
     console.log(bnf);


### PR DESCRIPTION
Fixes issue#2

url.searchParams.get returns a decoded string.

There is no need to call `decodeURIComponent` on it.

The seeming assymetry with *generateSaveURL* came from
*generateSaveURL* not using `URL.searchParams.set` to
construct the URL and instead using string append with
explicit `encodeURIComponent` calls.